### PR TITLE
Bugfixes in coco_assitant.py and coco_stats.py

### DIFF
--- a/coco_assistant/coco_assistant.py
+++ b/coco_assistant/coco_assistant.py
@@ -301,7 +301,7 @@ class COCO_Assistant():
 
         if dir_choice.lower() not in [item.lower() for item in self.imgfolders]:
             raise AssertionError("Choice not in images folder")
-        ind = self.imgfolders.index(dir_choice.lower())
+        ind = self.imgfolders.index(dir_choice)
         ann = self.annfiles[ind]
         img_dir = os.path.join(self.img_dir, dir_choice)
         cocovis.visualise_all(ann, img_dir)

--- a/coco_assistant/coco_stats.py
+++ b/coco_assistant/coco_stats.py
@@ -98,12 +98,12 @@ def get_object_size_split(ann, areaRng):
     left_out = len(ann.getAnnIds(areaRng=[0**2, (areaRng[0]**2)])) + len(ann.getAnnIds(areaRng=[areaRng[3]**2, (1e5**2)]))
 
     logging.debug("Number of small objects in set = %s", small)
-    logging.debug("Number of medium objects in set = %s".medium)
-    logging.debug("Number of large objects in set = %s".large)
+    logging.debug("Number of medium objects in set = %s", medium)
+    logging.debug("Number of large objects in set = %s", large)
     if left_out != 0:
         logging.debug("Number of objects ignored in set = %s", left_out)
 
-    logging.debug("Number of objects = %s".len(obj_areas))
+    logging.debug("Number of objects = %s", len(obj_areas))
 
     if len(obj_areas) != small + medium + large + left_out:
         raise AssertionError("Sum of objects in different area ranges != Total number of objects")


### PR DESCRIPTION
Minor bugs which resulted in the crashing of the scripts have been fixed.

To reproduce the bugs generate annotation statistics after creating the object:
`cas.ann_stats(stat="area",arearng=[10,144,512,1e5],save=False)`