### PR TITLE
Exclude Hidden folders from loading

### DIFF
--- a/coco_assistant/coco_assistant.py
+++ b/coco_assistant/coco_assistant.py
@@ -50,7 +50,7 @@ class COCO_Assistant():
         if os.path.exists(self.res_dir) is False:
             os.mkdir(self.res_dir)
 
-        self.imgfolders = sorted([i for i in os.listdir(self.img_dir) if os.path.isdir(os.path.join(self.img_dir, i)) is True])
+        self.imgfolders = sorted([i for i in os.listdir(self.img_dir) if (os.path.isdir(os.path.join(self.img_dir, i)) is True and not i.startswith('.'))])
         self.jsonfiles = sorted([j for j in os.listdir(ann_dir) if j[-5:] == ".json"])
         self.names = [n[:-5] for n in self.jsonfiles]
 


### PR DESCRIPTION
Hi,

Awesome tool you have here. 
I was working with Jupyter notebook and using this tool, but I was getting this error:
`AssertionError: Image dir and corresponding json file must have the same name`

I looked into it and the problem was that Jupyter creates these hidden directories named `.ipynb_checkpoints` everywhere and those were causing the problems. I found a simple solution, which should also exclude any other system related files from the search, while loading up datasets. Hope it helps. 