### PR TITLE
Closes #38

### DIFF
--- a/coco_assistant/coco_assistant.py
+++ b/coco_assistant/coco_assistant.py
@@ -65,7 +65,7 @@ class COCO_Assistant:
 
         self.names = imnames
 
-        # Note: Add check for confirming these folders only contain .jpg and .json respectively
+        # TODO: Add check for confirming these folders only contain .jpg and .json respectively
         logging.debug("Number of image folders = %s", len(self.imgfolders))
         logging.debug("Number of annotation files = %s", len(self.jsonfiles))
 
@@ -312,7 +312,7 @@ class COCO_Assistant:
 
 
 if __name__ == "__main__":
-    p = Path("/Users/ashwinnair/Desktop/COCO-Assistant/data/test/")
+    p = Path("/home/ashwin/Desktop/Projects/COCO-Assistant/data/tiny_coco/")
     img_dir = p / "images"
     ann_dir = p / "annotations"
 

--- a/coco_assistant/utils/misc.py
+++ b/coco_assistant/utils/misc.py
@@ -1,5 +1,6 @@
 import shutil
 
+
 def make_clean(dpath):
     if dpath.exists():
         shutil.rmtree(dpath)


### PR DESCRIPTION
The previous formulation was insufficient due to the `np.maximum` operation being carried out on category ids, which doesn't really mean anything. To effectively translate polygon to segmentation mask, area is a more important factor to be considered. To remedy this, the following steps were taken:

1. Construct a new area id mapping where the highest area id is allocated for the smallest area
2. Layer masks as before (using `np.maximum`) but on area ids.
3. Remap the area ids with category ids

This method ensures smaller polygons (regardless of category) remain on top. 

![mask_solved](https://user-images.githubusercontent.com/32295036/111911405-ec4e5100-8a7e-11eb-8de9-03d94e694cff.png)
