### PR TITLE
speed up the category removal operation

### DIFF
--- a/coco_assistant/coco_assistant.py
+++ b/coco_assistant/coco_assistant.py
@@ -244,16 +244,19 @@ class COCO_Assistant:
         catids_remove = ann.getCatIds(catNms=self.rcats)
         # Gives you a list of ids of annotations that contain those categories
         annids_remove = ann.getAnnIds(catIds=catids_remove)
-
-        # Remove from category list
-        cats = ann.loadCats(catids_remove)
-        # Remove from annotation list
-        anns = ann.loadAnns(annids_remove)
+        
+        # Get keep category ids
+        catids_keep = list(set(ann.getCatIds()) - set(catids_remove))
+        # Get keep annotation ids
+        annids_keep = list(set(ann.getAnnIds()) - set(annids_remove))
+        
         with open(self.ann_dir / json_name) as it:
             x = json.load(it)
-
-        x["categories"] = [i for i in x["categories"] if i not in cats]
-        x["annotations"] = [i for i in x["annotations"] if i not in anns]
+        
+        del x["categories"]
+        x["categories"] = ann.loadCats(catids_keep)
+        del x["annotations"]
+        x["annotations"] = ann.loadAnns(annids_keep)
 
         with open(resrm_dir / json_name, "w") as oa:
             json.dump(x, oa)


### PR DESCRIPTION
The original implementation of category removal is very slow when the .json file is very large (such as COCO train2017). I have tried to replace the list comprehensions in remove_cat() with some operations using COCO API. 