### PR TITLE
Support non-sequential category ids

### DIFF
--- a/coco_assistant/utils/remapper.py
+++ b/coco_assistant/utils/remapper.py
@@ -114,14 +114,16 @@ class CatRemapper:
         c2 = list(self.cat2.keys())
         diff = sorted(list(set(c2) - set(c1)))
 
+        max_c1_id = max(self.cat1.values())
+
         newcat_dict = {}
         overlap_dict = {}
         res = []
         if diff:
             # New categories
             for i, d in enumerate(diff):
-                newcat_dict[self.cat2[d]] = len(c1) + i + 1
-                self.result[d] = len(c1) + i + 1
+                newcat_dict[self.cat2[d]] = max_c1_id + i + 1
+                self.result[d] = max_c1_id + i + 1
                 del self.cat2[d]
 
             for k, v in self.result.items():


### PR DESCRIPTION
Adding support for merging non-sequential category ids (not starting a 1).
For example merging the following categories will result in `crate` having the same id as `pallet`:
`"categories": [
        {
            "id": 3,
            "name": "small_load_carrier",
            "supercategory": "",
            "color": "#e8e047",
            "metadata": {}
        },
        {
            "id": 5,
            "name": "forklift",
            "supercategory": "",
            "color": "#f8c718",
            "metadata": {}
        },
        {
            "id": 7,
            "name": "pallet",
            "supercategory": "",
            "color": "#8dd708",
            "metadata": {}
        },
        {
            "id": 10,
            "name": "stillage",
            "supercategory": "",
            "color": "#1640aa",
            "metadata": {}
        },
        {
            "id": 11,
            "name": "pallet_truck",
            "supercategory": "",
            "color": "#6ba8dc",
            "metadata": {}
        }
    ],`
and 
`"categories": [
        {
            "supercategory": "pallet",
            "id": 1,
            "name": "pallet"
        },
        {
            "supercategory": "load",
            "id": 2,
            "name": "load"
        },
        {
            "supercategory": "box",
            "id": 3,
            "name": "box"
        },
        {
            "supercategory": "crate",
            "id": 4,
            "name": "crate"
        }
    ]`